### PR TITLE
Load models from explicit files

### DIFF
--- a/prism/src/prism/PrismRapportTalker.java
+++ b/prism/src/prism/PrismRapportTalker.java
@@ -225,7 +225,7 @@ public class PrismRapportTalker
 			}
 			
 			boolean loadSuccess = loadPrismModelFile(modelPath, explicitModel);
-			
+
 			//if loading model failed
 			if(!loadSuccess) {
 				return null;
@@ -244,7 +244,7 @@ public class PrismRapportTalker
 			} else {
 				for(int i = 0; i < propList.size(); i++) {
 					String propString = propList.get(i);
-					PropertiesFile prismSpec = prism.parsePropertiesString(currentModel, propString);
+					PropertiesFile prismSpec = prism.parsePropertiesString(propString);
 					Expression expr = prismSpec.getProperty(0);
 					boolean doExplicitPolicyExport = !Expression.containsMultiObjective(expr) &&  !Expression.containsMaxReward(expr);
 					prism.setGenStrat(exportPolicy && doExplicitPolicyExport);
@@ -256,8 +256,7 @@ public class PrismRapportTalker
 						exportStratOptions.setMode(StrategyExportOptions.InducedModelMode.RESTRICT);
 						prism.exportStrategy(res.getStrategy(), exportStratOptions, new File(directory + modelFileName + "_adv.tra"));
 					}
-					
-				}	
+				}
 			}
 
 			

--- a/prism/src/prism/PrismRapportTalker.java
+++ b/prism/src/prism/PrismRapportTalker.java
@@ -119,17 +119,26 @@ public class PrismRapportTalker
 		System.out.println("loading prism model file");
 		if (explicit) {
 			System.out.println("Loading model from explicit files.");
-			// Trim the extension from the base model file. This is a very simple thing and will not work correctly for complex paths.
+			// Trim the extension from the base model file. This is a very simple thing and will
+			// not work correctly for complex paths. We can then use this to generate all the explicit
+			// files by concatenating the extensions.
 			String trimmedPath = modelPath.substring(0, modelPath.lastIndexOf('.'));
 			try{
 				File states = new File(trimmedPath + ".sta");
 				File transitions = new File(trimmedPath + ".tra");
 				File labels = new File(trimmedPath + ".lab");
+				if (!labels.exists()) {
+					labels = null;
+				}
 				File state_rewards = new File(trimmedPath + ".srew");
 				File transition_rewards = new File(trimmedPath + ".trew");
 				ArrayList<File> rewards = new ArrayList<>();
-				rewards.add(state_rewards);
-				rewards.add(transition_rewards);
+				if (state_rewards.exists()) {
+					rewards.add(state_rewards);
+				}
+				if (transition_rewards.exists()) {
+					rewards.add(transition_rewards);
+				}
 				prism.loadModelFromExplicitFiles(states, transitions, labels, rewards, null);
 				return true;
 			} catch (PrismException e) {

--- a/prism/src/prism/PrismRapportTalker.java
+++ b/prism/src/prism/PrismRapportTalker.java
@@ -130,16 +130,19 @@ public class PrismRapportTalker
 				if (!labels.exists()) {
 					labels = null;
 				}
-				File state_rewards = new File(trimmedPath + ".srew");
-				File transition_rewards = new File(trimmedPath + ".trew");
-				ArrayList<File> rewards = new ArrayList<>();
-				if (state_rewards.exists()) {
-					rewards.add(state_rewards);
+				File state_rewards_file = new File(trimmedPath + ".srew");
+				File transition_rewards_file = new File(trimmedPath + ".trew");
+				ArrayList<File> state_rewards = null;
+				ArrayList<File> transition_rewards = null;
+				if (state_rewards_file.exists()) {
+					state_rewards = new ArrayList<>();
+					state_rewards.add(state_rewards_file);
 				}
-				if (transition_rewards.exists()) {
-					rewards.add(transition_rewards);
+				if (transition_rewards_file.exists()) {
+					transition_rewards = new ArrayList<>();
+					transition_rewards.add(transition_rewards_file);
 				}
-				prism.loadModelFromExplicitFiles(states, transitions, labels, rewards, null);
+				prism.loadModelFromExplicitFiles(states, transitions, labels, state_rewards, transition_rewards, null);
 				return true;
 			} catch (PrismException e) {
 				System.out.println("Error: " + e.getMessage());

--- a/prism/src/prism/PrismRapportTalker.java
+++ b/prism/src/prism/PrismRapportTalker.java
@@ -30,7 +30,9 @@ package prism;
 import java.io.*;
 import java.net.*;
 import java.util.*;
-
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.nio.file.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Field;
@@ -109,9 +111,34 @@ public class PrismRapportTalker
 	/**
 	 * Function loads a PRISM file into Prism so it can be model checked
 	 * @param modelPath the path of the PRISM file
+	 * @param explicit use an explicit model. If provided, the model path should be the base path to the model files.
+	 *  For example, if the explicit files are test_dir/my_model.tra, test_dir/my_model.sta etc, you would pass test_dir/my_model as the modelPath.
 	 * @return the success status of the operation
 	 */
-	public boolean loadPrismModelFile(String modelPath){
+	public boolean loadPrismModelFile(String modelPath, boolean explicit){
+		System.out.println("loading prism model file");
+		if (explicit) {
+			System.out.println("Loading model from explicit files.");
+			// Trim the extension from the base model file. This is a very simple thing and will not work correctly for complex paths.
+			String trimmedPath = modelPath.substring(0, modelPath.lastIndexOf('.'));
+			try{
+				File states = new File(trimmedPath + ".sta");
+				File transitions = new File(trimmedPath + ".tra");
+				File labels = new File(trimmedPath + ".lab");
+				File state_rewards = new File(trimmedPath + ".srew");
+				File transition_rewards = new File(trimmedPath + ".trew");
+				ArrayList<File> rewards = new ArrayList<>();
+				rewards.add(state_rewards);
+				rewards.add(transition_rewards);
+				prism.loadModelFromExplicitFiles(states, transitions, labels, rewards, null);
+				return true;
+			} catch (PrismException e) {
+				System.out.println("Error: " + e.getMessage());
+				return false;
+			}
+		}
+
+		System.out.println("parsing model file and loading from that");
 		try{
 			currentModel = prism.parseModelFile(new File(modelPath));
 			prism.loadPRISMModel(currentModel);
@@ -157,7 +184,7 @@ public class PrismRapportTalker
 	 * @param getStateVector should the Result object store the state vector
 	 * @return An ArrayList of Result objects
 	 */
-	public ArrayList<Result> callPrism(ArrayList<String> propList, String modelPath, boolean exportPolicy, boolean exportInfoToFiles, boolean getStateVector, boolean doTransient)  {
+	public ArrayList<Result> callPrism(ArrayList<String> propList, String modelPath, boolean exportPolicy, boolean exportInfoToFiles, boolean getStateVector, boolean doTransient, boolean explicitModel)  {
 		try {
 			prism.setStoreVector(getStateVector);
 			
@@ -188,7 +215,7 @@ public class PrismRapportTalker
 				prism.setExportTarget(false);
 			}
 			
-			boolean loadSuccess = loadPrismModelFile(modelPath);
+			boolean loadSuccess = loadPrismModelFile(modelPath, explicitModel);
 			
 			//if loading model failed
 			if(!loadSuccess) {
@@ -414,11 +441,22 @@ public class PrismRapportTalker
 		while(run) { 
 			
 			command = in.readLine();
-			System.out.println("received: " + command); 
+			System.out.println("received: " + command);
 			if(command == null){
 				client = talker.server.accept();
 				System.out.println("got connection on port" + talker.getSocketPort());
 			} else {
+				boolean explicit = false;
+				String[] split_command = command.split(" ");
+				// The command is always the zeroth element of the first line we receive. If the split is longer than 1,
+				// then we need to check what the later values are. This is currently used to specify explicit models. This is easier than adding in 
+				// another line, because we would have to conditionally read that line for various models which would make the code below much messier.
+				command = split_command[0];
+				for (String command_extra: split_command) {
+					if (command_extra.equals("explicit_model")) {
+						explicit = true;
+					}
+				}
 
 				if (command.equals("configure")) {
 					talker.configurePrism(in, out);
@@ -461,7 +499,7 @@ public class PrismRapportTalker
 				//do trasnsient probabilities. only works for Markov chains
 				if (command.contains("transient")) {
 					try {
-						result = talker.callPrism(propList, modelFile, false, true, false, true);
+						result = talker.callPrism(propList, modelFile, false, true, false, true, explicit);
 						if (result == null) {
 							out.println(PrismRapportTalker.FAILURE);
 						} else {
@@ -477,7 +515,7 @@ public class PrismRapportTalker
 				// or for partial satisfiability guarantees
 				if (command.equals("check")){
 					try {
-						result = talker.callPrism(propList, modelFile, false, false, false, false);
+						result = talker.callPrism(propList, modelFile, false, false, false, false, explicit);
 						if (result != null && result.get(0) != null){
 							out.println(result.get(0).getResult().toString());
 						} else {
@@ -492,7 +530,7 @@ public class PrismRapportTalker
 				// command for planning and storing policies
 				if (command.equals("plan")){
 					try {
-						result=talker.callPrism(propList, modelFile, true, true, false, false);
+						result=talker.callPrism(propList, modelFile, true, true, false, false, explicit);
 						if(result != null && result.get(0) != null) {
 							out.println(talker.computeModelFileName(modelFile));
 						} else {
@@ -508,7 +546,7 @@ public class PrismRapportTalker
 				// command for returning state vector after model checking
 				if (command.equals("get_vector")){
 					try {
-						result=talker.callPrism(propList, modelFile, false, true, true, false);
+						result=talker.callPrism(propList, modelFile, false, true, true, false, explicit);
 						StateVector vect = result.get(0).getVector();
 						formattedResult = new ArrayList<String>();
 						for (int i = 0; i < vect.getSize(); i++) {
@@ -537,7 +575,7 @@ public class PrismRapportTalker
 						}
 						
 						// make the initial call to prism
-						result = talker.callPrism(propList, modelFile, false, false, true, false);
+						result = talker.callPrism(propList, modelFile, false, false, true, false, explicit);
 						if(result == null || result.get(0) == null) {
 							out.println(PrismRapportTalker.FAILURE);
 						}
@@ -567,7 +605,7 @@ public class PrismRapportTalker
 						}
 						
 						// Make the calls to prism
-						result = talker.callPrism(propList, modelFile, false, false, useInit, false);
+						result = talker.callPrism(propList, modelFile, false, false, useInit, false, explicit);
 						if(result == null || result.contains(null)) {
 							out.println(PrismRapportTalker.FAILURE);
 						}


### PR DESCRIPTION
These changes allow loading of models from `.sta`, `.tra` and the other explicit files that can be generated from a model using the `-exportmodel .all` command of PRISM.

For example, loading a ~70k state flat MDP takes approximately 300 seconds from the `to_prism_string` output. Converting the model to explicit files (which currently takes 300 seconds) and loading it using these changes takes 0.2 seconds.

I'm adding this because currently flat MDPs are extremely inefficient to load into PRISM because it has to do reachability on the model despite all states being enumerated already in the file. The `-exportmodel .all` command also does reachability if given the full prism model spec, so it's not possible to bypass reachability to generate the explicit files at the moment. PR to follow in other repos which allows conversion of flat MDP to the explicit files directly.

To do this I've had to make a slight change to how commands are passed to the rapport talker. The first line passed to the talker, which used to contain just the command like `plan`, `check`, etc, can  now look something like `plan explicit_model`. You can pass in space-separated strings as something like configuration arguments to the command. I did it this way because putting the explicit model flag on a new line would have required conditionally parsing it for each individual command, which would have been extremely messy.

There is currently an issue where the transition rewards are apparently not loaded. Have asked Dave for input on why it might not be working.

Here's a small example which can be used for testing

[tmp_model_small.zip](https://github.com/user-attachments/files/16411677/tmp_model_small.zip)

Use this python script

```
import shutil
import os
from rapport_external.prism_bridge import create_bridge

if __name__ == "__main__":
    model_dir = "tmp_model_small"
    model_name = "product_mdp"
    explicit_file_fstrings = ["{}.sta", "{}.tra", "{}.lab", "{}.srew", "{}.trew"]
    explicit_files = [fstr.format(model_name) for fstr in explicit_file_fstrings]
    model_file = os.path.join(model_dir, f"{model_name}.prism")
    model_id = "test_model"
    with open(model_file, "r") as f:
        model_string = f.read()

    with create_bridge(remove_dir=False, explicit_model=True) as bridge:
        bridge.add_model(model_id, model_string)
        bridge.configure_prism("prism.engine", "Hybrid")
        for exp_file_fstr in explicit_file_fstrings:
            shutil.copyfile(
                os.path.join(model_dir, exp_file_fstr.format(model_name)),
                os.path.join(bridge._work_dir, exp_file_fstr.format(model_id + "_model")),
            )

        bridge.call_prism_plan(model_id, "Rmax=? [ C ]")

```

